### PR TITLE
Added user registration/login endpoints

### DIFF
--- a/test/controllers/user_controller_test.exs
+++ b/test/controllers/user_controller_test.exs
@@ -1,0 +1,34 @@
+defmodule TrainWhistle.UserControllerTest do
+  use TrainWhistle.ConnCase
+
+  alias TrainWhistle.User
+  alias TrainWhistle.Repo
+  @valid_attrs %{email: "foobar@me.com", password: "s3cr3t", phone: "1-777-777-7777"}
+  @invalid_attrs %{}
+
+  setup %{conn: conn} do
+    hash = Comeonin.Bcrypt.hashpwsalt("pass")
+    {:ok, user} = Repo.insert %User{password_hash: hash, email: "me@mail.com"}
+    {:ok, jwt, full_claims} = Guardian.encode_and_sign(user)
+    json_conn = conn |> put_req_header("accept", "application/json")
+
+    {:ok, %{conn: json_conn, user: user, jwt: jwt, claims: full_claims }}
+  end
+
+  test "creates and renders resource when data is valid", %{conn: conn} do
+    conn = post conn, public_user_path(conn, :create), @valid_attrs
+    body = json_response(conn, 201)
+    assert body["id"]
+    assert body["email"]
+    assert body["phone"]
+    assert Repo.get_by(User, email: "foobar@me.com")
+  end
+
+  test "is able to log in", %{conn: conn} do
+    conn = post conn, public_user_path(conn, :login), %{email: "me@mail.com", password: "pass"}
+    body = json_response(conn, 200)
+    assert body["user"]
+    assert body["token"]
+    assert body["exp"]
+  end
+end

--- a/web/controllers/user_controller.ex
+++ b/web/controllers/user_controller.ex
@@ -1,0 +1,48 @@
+defmodule TrainWhistle.UserController do
+  use TrainWhistle.Web, :controller
+  alias TrainWhistle.User
+
+  def create(conn, user_params) do
+    changeset = User.registration_changeset(%User{}, user_params)
+
+    case Repo.insert(changeset) do
+      {:ok, user} ->
+        conn
+        |> put_status(:created)
+        |> render("show.json", user: user)
+      {:error, changeset} ->
+        conn
+        |> put_status(:unprocessable_entity)
+        |> render(TrainWhistle.ChangesetView, "error.json", changeset: changeset)
+    end
+  end
+
+  def login(conn, params) do
+    case User.authenticate(params) do
+      {:ok, user} ->
+        new_conn = Guardian.Plug.api_sign_in(conn, user)
+        jwt = Guardian.Plug.current_token(new_conn)
+        {:ok, claims} = Guardian.Plug.claims(new_conn)
+        exp = Map.get(claims, "exp")
+
+        new_conn
+        |> put_resp_header("authorization", "Bearer #{jwt}")
+        |> render("login.json", user: user, jwt: jwt, exp: exp)
+      :error ->
+        conn
+        |> put_status(:unauthorized)
+        |> json(%{message: "Incorrect email/password"})
+    end
+  end
+
+  def me(conn, _) do
+    user = Guardian.Plug.current_resource(conn)
+    conn |> render("show.json", user: user)
+  end
+
+  def unauthenticated(conn, _) do
+    conn 
+    |> put_status(:unauthorized)
+    |> json(%{message: "Not authorized"})
+  end
+end

--- a/web/models/user.ex
+++ b/web/models/user.ex
@@ -36,9 +36,10 @@ defmodule TrainWhistle.User do
   def changeset(struct, params \\ %{}) do
     struct
     |> cast(params, [:email, :phone])
-    |> validate_required([:email])
+    |> validate_required([:email, :phone])
     |> validate_length(:email, min: 3, max: 255)
     |> validate_format(:email, ~r/@/, message: "not a valid email.")
+    |> unique_constraint(:email)
   end
 
   @doc """
@@ -48,6 +49,7 @@ defmodule TrainWhistle.User do
     struct
     |> changeset(params)
     |> cast(params, [:password])
+    |> validate_required(:password)
     |> validate_length(:password, min: 6, message: "password must be at least 6 characters.")
     |> hash_password
   end

--- a/web/router.ex
+++ b/web/router.ex
@@ -11,6 +11,12 @@ defmodule TrainWhistle.Router do
 
   pipeline :api do
     plug :accepts, ["json"]
+    plug Guardian.Plug.VerifyHeader, realm: "Bearer"
+    plug Guardian.Plug.LoadResource
+  end
+
+  pipeline :authenticated do
+    plug Guardian.Plug.EnsureAuthenticated, handler: TrainWhistle.UserController
   end
 
   scope "/", TrainWhistle do
@@ -20,7 +26,18 @@ defmodule TrainWhistle.Router do
   end
 
   # Other scopes may use custom stacks.
-  # scope "/api", TrainWhistle do
-  #   pipe_through :api
-  # end
+  scope "/api", TrainWhistle do
+    pipe_through :api
+
+    scope as: :public do
+      post "/users", UserController, :create
+      post "/login", UserController, :login
+    end
+
+    scope as: :private do
+      pipe_through :authenticated
+
+      get "/me", UserController, :me
+    end
+  end
 end

--- a/web/views/changeset_view.ex
+++ b/web/views/changeset_view.ex
@@ -1,0 +1,21 @@
+defmodule TrainWhistle.ChangesetView do
+  use TrainWhistle.Web, :view
+
+  def render("error.json", %{changeset: changeset}) do
+    errors = Enum.map(changeset.errors, fn {field, detail} ->
+      %{field => render_detail(detail)}
+    end)
+
+    %{errors: errors}
+  end
+
+  def render_detail({message, values}) do
+    Enum.reduce values, message, fn {k, v}, acc ->
+      String.replace(acc, "%{#{k}}", to_string(v))
+    end
+  end
+
+  def render_detail(message) do
+    message
+  end
+end

--- a/web/views/user_view.ex
+++ b/web/views/user_view.ex
@@ -1,0 +1,18 @@
+defmodule TrainWhistle.UserView do
+  use TrainWhistle.Web, :view
+  @attributes ~w(id email phone)a
+
+  def render("show.json", %{user: user}) do
+    render_user(user)
+  end
+
+  def render("login.json", %{user: user, jwt: jwt, exp: exp}) do
+    %{user: render_user(user),
+      token: jwt,
+      exp: exp}
+  end
+
+  def render_user(user) do
+    user |> Map.take(@attributes)
+  end
+end


### PR DESCRIPTION
How this works:

you’ll make a POST request to `api/login` with your email and password
this will return a payload with the user object and a property called `token`
this token will be a long JWT
you just have to put that bad boy in localStorage or something, then on every subsequent request, you have to add the HTTP header `Authorization: Bearer <jwt>` where `jwt` is the token you got in that response.