### PR TITLE
add unique index to users' email

### DIFF
--- a/priv/repo/migrations/20161029184154_unique_e_mail_constraint.exs
+++ b/priv/repo/migrations/20161029184154_unique_e_mail_constraint.exs
@@ -1,0 +1,7 @@
+defmodule TrainWhistle.Repo.Migrations.UniqueEMailConstraint do
+  use Ecto.Migration
+
+  def change do
+    create unique_index(:users, :email)
+  end
+end


### PR DESCRIPTION
- Previously, a user could attempt to sign up with an existing e-mail
  address, preventing the previous user from signing in.